### PR TITLE
Icicle Updates

### DIFF
--- a/snakeviz/static/drawsvg.js
+++ b/snakeviz/static/drawsvg.js
@@ -150,22 +150,20 @@ var sv_update_info_div = function sv_update_info_div (d) {
     'cumulative_percent': (d.cumulative / sv_total_time * 100).toFixed(2)
   };
   var style = $('#sv-style-select').val();
-  if (style === "sunburst") {
-    $('#sv-info-div')
-      .html(sv_info_tpl(info))
-      .attr({
-        "class": "sunburst",
-        "height": radius * 1.5,
-        "width": ($('body').width() - (2 * radius)) / 2.1
-      });
-  } else if (style === "icicle") {
-    $('#sv-info-div')
-      .html(sv_info_tpl(info))
-      .attr({
-        "class": "icicle",
-        "height": 140,
-        "width": ($('body').width() * 0.6)
-      });
+  var div = $('#sv-info-div');
+  div.html(sv_info_tpl(info));
+  if ((style === "sunburst") & (!div.hasClass('sunburst'))) {
+    div
+      .addClass('sunburst')
+      .removeClass('icicle')
+      .height(radius * 1.5)
+      .width(($('body').width() - (2 * radius)) / 2.1);
+  } else if ((style === "icicle") & (!div.hasClass('icicle'))) {
+    div
+      .addClass('icicle')
+      .removeClass('sunburst')
+      .height(140)
+      .width($('body').width() * 0.6);
   }
 };
 

--- a/snakeviz/static/drawsvg.js
+++ b/snakeviz/static/drawsvg.js
@@ -7,7 +7,7 @@ var width = 0.8 * Math.min(window.innerHeight, window.innerWidth),
     height = width,
     radius = width / 2,
     scale = d3.scale.category20c();   // colors
-var icicle_top_margin = 240;
+var icicle_top_margin = 60;
 
 // should make it so that a given function is always the same color
 var color = function color(d) {
@@ -22,9 +22,9 @@ var make_vis_obj = function make_vis_obj (style) {
     height = width;
     transform = "translate(" + radius + "," + radius + ")";
   } else if (style === "icicle") {
-    width = 0.9 * window.innerWidth;
-    height = width * 0.4 + icicle_top_margin;
-    transform = "translate(0," + icicle_top_margin + ")";
+    width = 0.75 * window.innerWidth;
+    height = window.innerHeight * 0.8;
+    transform = "translate(90," + icicle_top_margin + ")";
   }
   return d3.select("#chart")
     .style('margin-left', 'auto')
@@ -149,9 +149,11 @@ var sv_update_info_div = function sv_update_info_div (d) {
     'cumulative': d.cumulative.toPrecision(3),
     'cumulative_percent': (d.cumulative / sv_total_time * 100).toFixed(2)
   };
+
   var style = $('#sv-style-select').val();
   var div = $('#sv-info-div');
   div.html(sv_info_tpl(info));
+
   if ((style === "sunburst") & (!div.hasClass('sunburst'))) {
     div
       .addClass('sunburst')
@@ -162,8 +164,8 @@ var sv_update_info_div = function sv_update_info_div (d) {
     div
       .addClass('icicle')
       .removeClass('sunburst')
-      .height(140)
-      .width($('body').width() * 0.6);
+      .height(radius * 1.5)
+      .width(200);
   }
 };
 

--- a/snakeviz/static/snakeviz.css
+++ b/snakeviz/static/snakeviz.css
@@ -99,17 +99,9 @@ select {
   display: table-cell;
 }
 
-#sv-info-div.sunburst {
+#sv-info-div {
   position: absolute;
   top: 240px;
-  display: none;
-  overflow: hidden;
-}
-
-#sv-info-div.icicle {
-  position: absolute;
-  top: 90px;
-  left: 300px;
   display: none;
   overflow: hidden;
 }


### PR DESCRIPTION
This will update jiffyclub/snakeviz#53. I've updated the JS that styles the info div so that it uses jQuery + CSS instead of attributes. I think that's the preferred way of setting styles like width/height. I've also re-arranged the layout so that info div stays on the left for both sunburst and icicle plots. It works a lot better that way on my 13" laptop screen.

Screenshot:

![screenshot 2015-04-02 12 14 31](https://cloud.githubusercontent.com/assets/920492/6971672/f6091d6e-d932-11e4-93fb-c7f0bb2d89bb.png)

What do you think?
